### PR TITLE
Use env in shebang.

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # MIT License                                              {
 #


### PR DESCRIPTION
While running initmux on Mac OS (FreeBSD), i ran into the following problem-
```
$ initmux                                                                                                                                             
bash: /Users/test/resources/software/installed//bin/initmux: /usr/bin/python3:                                                                        
bad interpreter: No such file or directory 
```                                                                                                           
This is because `python3` was install by `brew` in `/usr/local/bin/`-
```
$ which python3                                                                                                                                       
/usr/local/bin/python3
```
An easy way to fix this (and get initmux working on Mac OS with `brew`) is to use `env` in the shebang line.

Also, this has other benefits as mentioned in [this StackOverFlow question](https://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash).

Please review and merge the changes, if appropriate.